### PR TITLE
Add singularize table name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Usage of schemabuf:
         the database port (default 3306)
   -schema string
         the database schema (default "db_name")
+  -field_comment string
+        comment to field of message. Format: comment_prefix,position.
+        Position could be "top" or "right".
+        The comment will be generated with format: `comment_prefix:"field"`.
+        Example: `@injected_tag db:"id"`, with "@injected_tag db:" is comment_prefix,
+        and "id" is the field name of message.
+  -go_package string
+        Set value to option `option go_package="?";` when proto file was generated.
   -user string
         the database user (default "root")
 ```

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ func main() {
 	packageName := flag.String("package", *schema, "the protocol buffer package. defaults to the database schema.")
 	ignoreTableStr := flag.String("ignore_tables", "", "a comma spaced list of tables to ignore")
 	singularizeTblName := flag.Bool("singularize_table_name", true, "singularize table name (message name)")
+	fieldCommentStr := flag.String("field_comment", ",", "field comment, format: comment_prefix,position")
 
 	flag.Parse()
 
@@ -34,9 +35,12 @@ func main() {
 	defer db.Close()
 
 	ignoreTables := strings.Split(*ignoreTableStr, ",")
+	cmtInfo := strings.Split(*fieldCommentStr, ",")
 	genOptions := schemabuf.GenerationOptions{
 		PkgName: *packageName,
 		SingularizeTblName: *singularizeTblName,
+		FieldCommentPrefix: cmtInfo[0],
+		FieldCommentPosition: cmtInfo[1],
 	}
 	s, err := schemabuf.GenerateSchema(db, ignoreTables, genOptions)
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 	ignoreTableStr := flag.String("ignore_tables", "", "a comma spaced list of tables to ignore")
 	singularizeTblName := flag.Bool("singularize_table_name", true, "singularize table name (message name)")
 	fieldCommentStr := flag.String("field_comment", ",", "field comment, format: comment_prefix,position")
+	goPkgStr := flag.String("go_package", "", "value for `option go_package` option")
 
 	flag.Parse()
 
@@ -37,10 +38,11 @@ func main() {
 	ignoreTables := strings.Split(*ignoreTableStr, ",")
 	cmtInfo := strings.Split(*fieldCommentStr, ",")
 	genOptions := schemabuf.GenerationOptions{
-		PkgName: *packageName,
-		SingularizeTblName: *singularizeTblName,
-		FieldCommentPrefix: cmtInfo[0],
+		PkgName:              *packageName,
+		SingularizeTblName:   *singularizeTblName,
+		FieldCommentPrefix:   cmtInfo[0],
 		FieldCommentPosition: cmtInfo[1],
+		GoPackage:            *goPkgStr,
 	}
 	s, err := schemabuf.GenerateSchema(db, ignoreTables, genOptions)
 

--- a/schemabuf/schemabuf.go
+++ b/schemabuf/schemabuf.go
@@ -30,6 +30,7 @@ type GenerationOptions struct {
 	SingularizeTblName   bool
 	FieldCommentPrefix   string
 	FieldCommentPosition string
+	GoPackage            string // value for option go_package="?";
 }
 
 // GenerateSchema generates a protobuf schema from a database connection and a package name.
@@ -209,16 +210,24 @@ func (s *Schema) String() string {
 	buf.WriteString("\n")
 	buf.WriteString("// ------------------------------------ \n")
 	buf.WriteString("// Imports\n")
-	buf.WriteString("// ------------------------------------ \n\n")
+	buf.WriteString("// ------------------------------------ \n")
 
 	for _, i := range s.Imports {
 		buf.WriteString(fmt.Sprintf("import \"%s\";\n", i))
 	}
 
+	if s.genOpts.GoPackage != "" {
+		buf.WriteString("\n")
+		buf.WriteString("// ------------------------------------ \n")
+		buf.WriteString("// Options\n")
+		buf.WriteString("// ------------------------------------ \n")
+		buf.WriteString(fmt.Sprintf("option go_package=\"%s\";\n", s.genOpts.GoPackage))
+	}
+
 	buf.WriteString("\n")
 	buf.WriteString("// ------------------------------------ \n")
 	buf.WriteString("// Messages\n")
-	buf.WriteString("// ------------------------------------ \n\n")
+	buf.WriteString("// ------------------------------------ \n")
 
 	for _, m := range s.Messages {
 		buf.WriteString(fmt.Sprintf("%s\n", m.String(s.genOpts.FieldCommentPrefix, s.genOpts.FieldCommentPosition)))


### PR DESCRIPTION
Add `field_comment` and `go_package` options.

```
 -field_comment string
        comment to field of message. Format: comment_prefix,position.
        Position could be "top" or "right".
        The comment will be generated with format: `comment_prefix:"field"`.
        Example: `@injected_tag db:"id"`, with "@injected_tag db:" is comment_prefix,
        and "id" is the field name of message.
  -go_package string
        Set value to option `option go_package="?";` when proto file was generated.
```